### PR TITLE
Enable installation with setuptools >=58

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools<58", "wheel"]


### PR DESCRIPTION
setuptools v58.0.0 removed support for `use_2to3` during builds. This patch simply adds a `pyproject.toml` that pins setuptools to a version smaller than 58.0.0. It's a bare minimum band-aid to get pagan to install with a new version of setuptools.