### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup
 setup(
     name='pagan',
     packages=['pagan'],
-    use_2to3=True,
     include_package_data=True,
     version='0.4.3',
     url='https://github.com/daboth/pagan',


### PR DESCRIPTION
removed  use_2to3=True in setup.py
installation results in error related to an update in setuptools

v58.0.2
06 Sep 2021
Misc
    #2769: Build now fails fast when use_2to3 is supplied.

i cloed it better to just fix setuptools version 
