### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ execute the following instructions from the webserver directory:
 Beware: This demo of Pagan will fill your temporary directory with generated
 image files. Do not run it in production!
 
-The webserver will serve from localhost port 8080. Open this adress in your
+The webserver will serve from localhost port 8080. Open this address in your
 browser window:
 ```
 http://127.0.0.1:8080/
@@ -156,13 +156,13 @@ Then, run docker image
 >> docker run -d -p 8080:8080 -t pagan
 ```
 
-The webserver inside Docker will serve from localhost port 8080. Open this adress in your
+The webserver inside Docker will serve from localhost port 8080. Open this address in your
 browser window:
 ```
 http://127.0.0.1:8080/
 ```
 
-If you want to use PAGAN CLI, you just have to look for the IP Adress of the Docker container and then connect through ssh with user: pagan and pass: pagan, like this:
+If you want to use PAGAN CLI, you just have to look for the IP Address of the Docker container and then connect through ssh with user: pagan and pass: pagan, like this:
 
 ```
 >> ssh -X pagan@dockercontainerip

--- a/pagan/hashgrinder.py
+++ b/pagan/hashgrinder.py
@@ -94,14 +94,14 @@ def init_weapon_list():
 def grind_hash_for_colors(hashcode):
     """Extracts information from the hashcode
     to generate different colors. Returns a
-    list of colors in (r,g,b) tupels."""
+    list of colors in (r,g,b) tuples."""
 
     # When using smaller hash algorithms like MD5 or SHA1,
     # the number of bits does not provide enough information
     # to generate unique colors. Instead the hash is internally
     # appended by itself to fit the MINIMUM_HASH_LEN.
     # This leads to smaller hashes displaying less color
-    # variatons, depicting the insecurity of small hashes.
+    # variations, depicting the insecurity of small hashes.
     while (len(hashcode) < MINIMUM_HASH_LEN):
         chardiff = diff(len(hashcode), MINIMUM_HASH_LEN)
         if DEBUG:

--- a/pagan/pgnreader.py
+++ b/pagan/pgnreader.py
@@ -19,7 +19,7 @@ FIXED_PIXEL = 'o'
 OPTIONAL_PIXEL = '+'
 
 # TODO: Split into two methods - Finding fixed pixels and optional pixels?
-# Less efficient but does not damage my brain. Or generate a tupel of two lists in a seperate method
+# Less efficient but does not damage my brain. Or generate a tuple of two lists in a separate method
 # and handle them differently.
 def parse_pagan_file(filename, hashcode, sym=False, invert=False):
     fd = open(filename, 'r')


### PR DESCRIPTION
There are small typos in:
- README.md
- pagan/hashgrinder.py
- pagan/pgnreader.py

Fixes:
- Should read `address` rather than `adress`.
- Should read `variations` rather than `variatons`.
- Should read `tuples` rather than `tupels`.
- Should read `tuple` rather than `tupel`.
- Should read `separate` rather than `seperate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md