### PR TITLE
Fixed use_2to_3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='pagan',
     packages=['pagan'],
-    use_2to3=True,
+    use_2to3=False,
     include_package_data=True,
     version='0.4.3',
     url='https://github.com/daboth/pagan',


### PR DESCRIPTION
Switching flag to false resolves pip installation erros and running python setup. At least in python 3.9.
Errors:  
```
#setup
python .\setup.py
error in pagan setup command: use_2to3 is invalid.
```
```
#pip
pip install pagan
Collecting pagan
  Using cached pagan-0.4.3.tar.gz (21 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in pagan setup command: use_2to3 is invalid.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```
Think leaving this as default config is neeeded since python2 is deprecated 